### PR TITLE
feat: set release_status to production/stable

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/bigquery/transfer/",
   "client_documentation": "https://googleapis.dev/python/bigquerydatatransfer/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-bigquery-datatransfer",
   "distribution_name": "google-cloud-bigquery-datatransfer",

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Client for BigQuery Data Transfer API
 ============================================
 
-|alpha| |pypi| |versions| 
+|GA| |pypi| |versions| 
 
 The `BigQuery Data Transfer API`_ allows users to transfer data from partner
 SaaS applications to Google BigQuery on a scheduled, managed basis.
@@ -9,8 +9,8 @@ SaaS applications to Google BigQuery on a scheduled, managed basis.
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+.. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-bigquery-datatransfer.svg
    :target: https://pypi.org/project/google-cloud-bigquery-datatransfer/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-datatransfer.svg

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ version = "0.4.1"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 


### PR DESCRIPTION
Release-As: 1.0.0

The underlying BigQuery Datatransfer API is GA and this library has not had major changes since last Fall (https://github.com/googleapis/python-bigquery-datatransfer/blob/master/CHANGELOG.md). 

[GA release template](https://github.com/googleapis/google-cloud-common/issues/287)
## Required 

- [x] 28 days elapsed since last beta release with new API surface
- [x] Server API is GA
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA
