### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "bigquerydatatransfer",
-  "name_pretty": "Google BigQuery Data Transfer Service",
-  "product_documentation": "https://cloud.google.com/bigquery/transfer/",
-  "client_documentation": "https://googleapis.dev/python/bigquerydatatransfer/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-bigquery-datatransfer",
-  "distribution_name": "google-cloud-bigquery-datatransfer",
-  "api_id": "bigquerydatatransfer.googleapis.com",
-  "requires_billing": true
+    "name": "bigquerydatatransfer",
+    "name_pretty": "Google BigQuery Data Transfer Service",
+    "product_documentation": "https://cloud.google.com/bigquery/transfer/",
+    "client_documentation": "https://googleapis.dev/python/bigquerydatatransfer/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-bigquery-datatransfer",
+    "distribution_name": "google-cloud-bigquery-datatransfer",
+    "api_id": "bigquerydatatransfer.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-bigquery-datatransfer",
     "api_id": "bigquerydatatransfer.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
-    "codeowner_team": ""
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/api-bigquery"
 }


### PR DESCRIPTION
Set codeowner_team to @googleapis/api-bigquery as codeowner. Set default_version to v1. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114