### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquerydatatransfer",
     "name_pretty": "Google BigQuery Data Transfer Service",
     "product_documentation": "https://cloud.google.com/bigquery/transfer/",
-    "client_documentation": "https://googleapis.dev/python/bigquerydatatransfer/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerydatatransfer/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ SaaS applications to Google BigQuery on a scheduled, managed basis.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-datatransfer.svg
    :target: https://pypi.org/project/google-cloud-bigquery-datatransfer/
 .. _BigQuery Data Transfer API: https://cloud.google.com/bigquery/transfer
-.. _Client Library Documentation: https://googleapis.dev/python/bigquerydatatransfer/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerydatatransfer/latest
 .. _Product Documentation:  https://cloud.google.com/bigquery/docs/transfer-service-overview
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.