### PR TITLE
fix(doc): Remove new line in documentation comment

### DIFF
--- a/google/cloud/bigquery_datatransfer_v1/types/transfer.py
+++ b/google/cloud/bigquery_datatransfer_v1/types/transfer.py
@@ -133,8 +133,7 @@ class TransferConfig(proto.Message):
             up a data transfer' section for each data
             source. For example the parameters for Cloud
             Storage transfers are listed here:
-            https://cloud.google.com/bigquery-
-            transfer/docs/cloud-storage-transfer#bq
+            https://cloud.google.com/bigquery-transfer/docs/cloud-storage-transfer#bq
         schedule (str):
             Data transfer schedule. If the data source does not support
             a custom schedule, this should be empty. If it is empty, the


### PR DESCRIPTION
The newline in the comment caused a space in the generated documentation, breaking the link. Removing the newline should fix the link in the generated doc (see line 146 for an example of this already in the file).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-datatransfer/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #266 
