### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v2 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,9 +67,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-bigquery-datatransfer"
-copyright = u"2019, Google"
-author = u"Google APIs"
+project = "google-cloud-bigquery-datatransfer"
+copyright = "2019, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -268,7 +268,7 @@ latex_documents = [
     (
         master_doc,
         "google-cloud-bigquery-datatransfer.tex",
-        u"google-cloud-bigquery-datatransfer Documentation",
+        "google-cloud-bigquery-datatransfer Documentation",
         author,
         "manual",
     )
@@ -303,7 +303,7 @@ man_pages = [
     (
         master_doc,
         "google-cloud-bigquery-datatransfer",
-        u"google-cloud-bigquery-datatransfer Documentation",
+        "google-cloud-bigquery-datatransfer Documentation",
         [author],
         1,
     )
@@ -322,7 +322,7 @@ texinfo_documents = [
     (
         master_doc,
         "google-cloud-bigquery-datatransfer",
-        u"google-cloud-bigquery-datatransfer Documentation",
+        "google-cloud-bigquery-datatransfer Documentation",
         author,
         "google-cloud-bigquery-datatransfer",
         "google-cloud-bigquery-datatransfer Library",
@@ -347,7 +347,10 @@ texinfo_documents = [
 intersphinx_mapping = {
     "python": ("http://python.readthedocs.org/en/latest/", None),
     "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None,),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
     "grpc": ("https://grpc.io/grpc/python/", None),
 }
 

--- a/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
+++ b/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/async_client.py
@@ -179,7 +179,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -193,7 +194,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -264,7 +270,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -278,12 +285,20 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListDataSourcesAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -379,7 +394,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -469,7 +489,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -532,7 +557,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -547,7 +573,10 @@ class DataTransferServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def get_transfer_config(
@@ -617,7 +646,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -631,7 +661,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -701,7 +736,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -715,12 +751,20 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListTransferConfigsAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -815,7 +859,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -869,7 +918,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -936,7 +990,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -950,7 +1005,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1012,7 +1072,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -1027,7 +1088,10 @@ class DataTransferServiceAsyncClient:
 
         # Send the request.
         await rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     async def list_transfer_runs(
@@ -1098,7 +1162,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -1112,12 +1177,20 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListTransferRunsAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1189,7 +1262,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -1203,12 +1277,20 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListTransferLogsAsyncPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1288,7 +1370,8 @@ class DataTransferServiceAsyncClient:
                 maximum=60.0,
                 multiplier=1.3,
                 predicate=retries.if_exception_type(
-                    exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                    exceptions.ServiceUnavailable,
+                    exceptions.DeadlineExceeded,
                 ),
             ),
             default_timeout=20.0,
@@ -1302,7 +1385,12 @@ class DataTransferServiceAsyncClient:
         )
 
         # Send the request.
-        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response

--- a/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
+++ b/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/client.py
@@ -61,7 +61,8 @@ class DataTransferServiceClientMeta(type):
     _transport_registry["grpc_asyncio"] = DataTransferServiceGrpcAsyncIOTransport
 
     def get_transport_class(
-        cls, label: str = None,
+        cls,
+        label: str = None,
     ) -> Type[DataTransferServiceTransport]:
         """Return an appropriate transport class.
 
@@ -143,10 +144,14 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
     from_service_account_json = from_service_account_file
 
     @staticmethod
-    def transfer_config_path(project: str, transfer_config: str,) -> str:
+    def transfer_config_path(
+        project: str,
+        transfer_config: str,
+    ) -> str:
         """Return a fully-qualified transfer_config string."""
         return "projects/{project}/transferConfigs/{transfer_config}".format(
-            project=project, transfer_config=transfer_config,
+            project=project,
+            transfer_config=transfer_config,
         )
 
     @staticmethod
@@ -193,10 +198,10 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
                 not provided, the default SSL client certificate will be used if
                 present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
                 set, no client certificate will be used.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
 
         Raises:
@@ -347,7 +352,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -426,12 +436,20 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListDataSourcesPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -529,7 +547,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -621,7 +644,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -693,7 +721,10 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def get_transfer_config(
@@ -771,7 +802,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -849,12 +885,20 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListTransferConfigsPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -951,7 +995,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1008,7 +1057,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1083,7 +1137,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response
@@ -1154,7 +1213,10 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
 
         # Send the request.
         rpc(
-            request, retry=retry, timeout=timeout, metadata=metadata,
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
         )
 
     def list_transfer_runs(
@@ -1233,12 +1295,20 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListTransferRunsPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1318,12 +1388,20 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListTransferLogsPager(
-            method=rpc, request=request, response=response, metadata=metadata,
+            method=rpc,
+            request=request,
+            response=response,
+            metadata=metadata,
         )
 
         # Done; return the response.
@@ -1411,7 +1489,12 @@ class DataTransferServiceClient(metaclass=DataTransferServiceClientMeta):
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
         # Done; return the response.
         return response

--- a/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
+++ b/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/base.py
@@ -71,10 +71,10 @@ class DataTransferServiceTransport(abc.ABC):
             scope (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
         """
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
@@ -115,7 +115,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -128,7 +129,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -151,7 +153,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -164,7 +167,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -177,7 +181,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -200,7 +205,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -213,7 +219,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -226,7 +233,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -239,7 +247,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,
@@ -252,7 +261,8 @@ class DataTransferServiceTransport(abc.ABC):
                     maximum=60.0,
                     multiplier=1.3,
                     predicate=retries.if_exception_type(
-                        exceptions.ServiceUnavailable, exceptions.DeadlineExceeded,
+                        exceptions.ServiceUnavailable,
+                        exceptions.DeadlineExceeded,
                     ),
                 ),
                 default_timeout=20.0,

--- a/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
+++ b/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc.py
@@ -94,10 +94,10 @@ class DataTransferServiceGrpcTransport(DataTransferServiceTransport):
                 for grpc channel. It is ignored if ``channel`` is provided.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
 
         Raises:

--- a/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
+++ b/google/cloud/bigquery_datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py
@@ -139,10 +139,10 @@ class DataTransferServiceGrpcAsyncIOTransport(DataTransferServiceTransport):
                 for grpc channel. It is ignored if ``channel`` is provided.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
 
         Raises:

--- a/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
+++ b/google/cloud/bigquery_datatransfer_v1/types/datatransfer.py
@@ -122,7 +122,11 @@ class DataSourceParameter(proto.Message):
 
     description = proto.Field(proto.STRING, number=3)
 
-    type = proto.Field(proto.ENUM, number=4, enum=Type,)
+    type = proto.Field(
+        proto.ENUM,
+        number=4,
+        enum=Type,
+    )
 
     required = proto.Field(proto.BOOL, number=5)
 
@@ -132,12 +136,22 @@ class DataSourceParameter(proto.Message):
 
     allowed_values = proto.RepeatedField(proto.STRING, number=8)
 
-    min_value = proto.Field(proto.MESSAGE, number=9, message=wrappers.DoubleValue,)
+    min_value = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=wrappers.DoubleValue,
+    )
 
-    max_value = proto.Field(proto.MESSAGE, number=10, message=wrappers.DoubleValue,)
+    max_value = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=wrappers.DoubleValue,
+    )
 
     fields = proto.RepeatedField(
-        proto.MESSAGE, number=11, message="DataSourceParameter",
+        proto.MESSAGE,
+        number=11,
+        message="DataSourceParameter",
     )
 
     validation_description = proto.Field(proto.STRING, number=12)
@@ -240,7 +254,11 @@ class DataSource(proto.Message):
 
     scopes = proto.RepeatedField(proto.STRING, number=6)
 
-    transfer_type = proto.Field(proto.ENUM, number=7, enum=transfer.TransferType,)
+    transfer_type = proto.Field(
+        proto.ENUM,
+        number=7,
+        enum=transfer.TransferType,
+    )
 
     supports_multiple_transfers = proto.Field(proto.BOOL, number=8)
 
@@ -251,21 +269,33 @@ class DataSource(proto.Message):
     supports_custom_schedule = proto.Field(proto.BOOL, number=11)
 
     parameters = proto.RepeatedField(
-        proto.MESSAGE, number=12, message=DataSourceParameter,
+        proto.MESSAGE,
+        number=12,
+        message=DataSourceParameter,
     )
 
     help_url = proto.Field(proto.STRING, number=13)
 
-    authorization_type = proto.Field(proto.ENUM, number=14, enum=AuthorizationType,)
+    authorization_type = proto.Field(
+        proto.ENUM,
+        number=14,
+        enum=AuthorizationType,
+    )
 
-    data_refresh_type = proto.Field(proto.ENUM, number=15, enum=DataRefreshType,)
+    data_refresh_type = proto.Field(
+        proto.ENUM,
+        number=15,
+        enum=DataRefreshType,
+    )
 
     default_data_refresh_window_days = proto.Field(proto.INT32, number=16)
 
     manual_runs_disabled = proto.Field(proto.BOOL, number=17)
 
     minimum_schedule_interval = proto.Field(
-        proto.MESSAGE, number=18, message=duration.Duration,
+        proto.MESSAGE,
+        number=18,
+        message=duration.Duration,
     )
 
 
@@ -329,7 +359,11 @@ class ListDataSourcesResponse(proto.Message):
     def raw_page(self):
         return self
 
-    data_sources = proto.RepeatedField(proto.MESSAGE, number=1, message=DataSource,)
+    data_sources = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message=DataSource,
+    )
 
     next_page_token = proto.Field(proto.STRING, number=2)
 
@@ -392,7 +426,9 @@ class CreateTransferConfigRequest(proto.Message):
     parent = proto.Field(proto.STRING, number=1)
 
     transfer_config = proto.Field(
-        proto.MESSAGE, number=2, message=transfer.TransferConfig,
+        proto.MESSAGE,
+        number=2,
+        message=transfer.TransferConfig,
     )
 
     authorization_code = proto.Field(proto.STRING, number=3)
@@ -451,12 +487,18 @@ class UpdateTransferConfigRequest(proto.Message):
     """
 
     transfer_config = proto.Field(
-        proto.MESSAGE, number=1, message=transfer.TransferConfig,
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferConfig,
     )
 
     authorization_code = proto.Field(proto.STRING, number=3)
 
-    update_mask = proto.Field(proto.MESSAGE, number=4, message=field_mask.FieldMask,)
+    update_mask = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=field_mask.FieldMask,
+    )
 
     version_info = proto.Field(proto.STRING, number=5)
 
@@ -573,7 +615,9 @@ class ListTransferConfigsResponse(proto.Message):
         return self
 
     transfer_configs = proto.RepeatedField(
-        proto.MESSAGE, number=1, message=transfer.TransferConfig,
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferConfig,
     )
 
     next_page_token = proto.Field(proto.STRING, number=2)
@@ -615,13 +659,21 @@ class ListTransferRunsRequest(proto.Message):
 
     parent = proto.Field(proto.STRING, number=1)
 
-    states = proto.RepeatedField(proto.ENUM, number=2, enum=transfer.TransferState,)
+    states = proto.RepeatedField(
+        proto.ENUM,
+        number=2,
+        enum=transfer.TransferState,
+    )
 
     page_token = proto.Field(proto.STRING, number=3)
 
     page_size = proto.Field(proto.INT32, number=4)
 
-    run_attempt = proto.Field(proto.ENUM, number=5, enum=RunAttempt,)
+    run_attempt = proto.Field(
+        proto.ENUM,
+        number=5,
+        enum=RunAttempt,
+    )
 
 
 class ListTransferRunsResponse(proto.Message):
@@ -643,7 +695,9 @@ class ListTransferRunsResponse(proto.Message):
         return self
 
     transfer_runs = proto.RepeatedField(
-        proto.MESSAGE, number=1, message=transfer.TransferRun,
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferRun,
     )
 
     next_page_token = proto.Field(proto.STRING, number=2)
@@ -681,7 +735,9 @@ class ListTransferLogsRequest(proto.Message):
     page_size = proto.Field(proto.INT32, number=5)
 
     message_types = proto.RepeatedField(
-        proto.ENUM, number=6, enum=transfer.TransferMessage.MessageSeverity,
+        proto.ENUM,
+        number=6,
+        enum=transfer.TransferMessage.MessageSeverity,
     )
 
 
@@ -704,7 +760,9 @@ class ListTransferLogsResponse(proto.Message):
         return self
 
     transfer_messages = proto.RepeatedField(
-        proto.MESSAGE, number=1, message=transfer.TransferMessage,
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferMessage,
     )
 
     next_page_token = proto.Field(proto.STRING, number=2)
@@ -759,9 +817,17 @@ class ScheduleTransferRunsRequest(proto.Message):
 
     parent = proto.Field(proto.STRING, number=1)
 
-    start_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message=timestamp.Timestamp,
+    )
 
-    end_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    end_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp.Timestamp,
+    )
 
 
 class ScheduleTransferRunsResponse(proto.Message):
@@ -772,7 +838,11 @@ class ScheduleTransferRunsResponse(proto.Message):
             The transfer runs that were scheduled.
     """
 
-    runs = proto.RepeatedField(proto.MESSAGE, number=1, message=transfer.TransferRun,)
+    runs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferRun,
+    )
 
 
 class StartManualTransferRunsRequest(proto.Message):
@@ -810,18 +880,32 @@ class StartManualTransferRunsRequest(proto.Message):
                 range betwen start_time (inclusive) and end_time (exlusive).
         """
 
-        start_time = proto.Field(proto.MESSAGE, number=1, message=timestamp.Timestamp,)
+        start_time = proto.Field(
+            proto.MESSAGE,
+            number=1,
+            message=timestamp.Timestamp,
+        )
 
-        end_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
+        end_time = proto.Field(
+            proto.MESSAGE,
+            number=2,
+            message=timestamp.Timestamp,
+        )
 
     parent = proto.Field(proto.STRING, number=1)
 
     requested_time_range = proto.Field(
-        proto.MESSAGE, number=3, oneof="time", message=TimeRange,
+        proto.MESSAGE,
+        number=3,
+        oneof="time",
+        message=TimeRange,
     )
 
     requested_run_time = proto.Field(
-        proto.MESSAGE, number=4, oneof="time", message=timestamp.Timestamp,
+        proto.MESSAGE,
+        number=4,
+        oneof="time",
+        message=timestamp.Timestamp,
     )
 
 
@@ -833,7 +917,11 @@ class StartManualTransferRunsResponse(proto.Message):
             The transfer runs that were created.
     """
 
-    runs = proto.RepeatedField(proto.MESSAGE, number=1, message=transfer.TransferRun,)
+    runs = proto.RepeatedField(
+        proto.MESSAGE,
+        number=1,
+        message=transfer.TransferRun,
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/google/cloud/bigquery_datatransfer_v1/types/transfer.py
+++ b/google/cloud/bigquery_datatransfer_v1/types/transfer.py
@@ -97,9 +97,17 @@ class ScheduleOptions(proto.Message):
 
     disable_auto_scheduling = proto.Field(proto.BOOL, number=3)
 
-    start_time = proto.Field(proto.MESSAGE, number=1, message=timestamp.Timestamp,)
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message=timestamp.Timestamp,
+    )
 
-    end_time = proto.Field(proto.MESSAGE, number=2, message=timestamp.Timestamp,)
+    end_time = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        message=timestamp.Timestamp,
+    )
 
 
 class TransferConfig(proto.Message):
@@ -188,21 +196,41 @@ class TransferConfig(proto.Message):
 
     data_source_id = proto.Field(proto.STRING, number=5)
 
-    params = proto.Field(proto.MESSAGE, number=9, message=struct.Struct,)
+    params = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=struct.Struct,
+    )
 
     schedule = proto.Field(proto.STRING, number=7)
 
-    schedule_options = proto.Field(proto.MESSAGE, number=24, message=ScheduleOptions,)
+    schedule_options = proto.Field(
+        proto.MESSAGE,
+        number=24,
+        message=ScheduleOptions,
+    )
 
     data_refresh_window_days = proto.Field(proto.INT32, number=12)
 
     disabled = proto.Field(proto.BOOL, number=13)
 
-    update_time = proto.Field(proto.MESSAGE, number=4, message=timestamp.Timestamp,)
+    update_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp.Timestamp,
+    )
 
-    next_run_time = proto.Field(proto.MESSAGE, number=8, message=timestamp.Timestamp,)
+    next_run_time = proto.Field(
+        proto.MESSAGE,
+        number=8,
+        message=timestamp.Timestamp,
+    )
 
-    state = proto.Field(proto.ENUM, number=10, enum="TransferState",)
+    state = proto.Field(
+        proto.ENUM,
+        number=10,
+        enum="TransferState",
+    )
 
     user_id = proto.Field(proto.INT64, number=11)
 
@@ -210,7 +238,11 @@ class TransferConfig(proto.Message):
 
     notification_pubsub_topic = proto.Field(proto.STRING, number=15)
 
-    email_preferences = proto.Field(proto.MESSAGE, number=18, message=EmailPreferences,)
+    email_preferences = proto.Field(
+        proto.MESSAGE,
+        number=18,
+        message=EmailPreferences,
+    )
 
 
 class TransferRun(proto.Message):
@@ -273,25 +305,57 @@ class TransferRun(proto.Message):
 
     name = proto.Field(proto.STRING, number=1)
 
-    schedule_time = proto.Field(proto.MESSAGE, number=3, message=timestamp.Timestamp,)
+    schedule_time = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        message=timestamp.Timestamp,
+    )
 
-    run_time = proto.Field(proto.MESSAGE, number=10, message=timestamp.Timestamp,)
+    run_time = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=timestamp.Timestamp,
+    )
 
-    error_status = proto.Field(proto.MESSAGE, number=21, message=status.Status,)
+    error_status = proto.Field(
+        proto.MESSAGE,
+        number=21,
+        message=status.Status,
+    )
 
-    start_time = proto.Field(proto.MESSAGE, number=4, message=timestamp.Timestamp,)
+    start_time = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        message=timestamp.Timestamp,
+    )
 
-    end_time = proto.Field(proto.MESSAGE, number=5, message=timestamp.Timestamp,)
+    end_time = proto.Field(
+        proto.MESSAGE,
+        number=5,
+        message=timestamp.Timestamp,
+    )
 
-    update_time = proto.Field(proto.MESSAGE, number=6, message=timestamp.Timestamp,)
+    update_time = proto.Field(
+        proto.MESSAGE,
+        number=6,
+        message=timestamp.Timestamp,
+    )
 
-    params = proto.Field(proto.MESSAGE, number=9, message=struct.Struct,)
+    params = proto.Field(
+        proto.MESSAGE,
+        number=9,
+        message=struct.Struct,
+    )
 
     destination_dataset_id = proto.Field(proto.STRING, number=2, oneof="destination")
 
     data_source_id = proto.Field(proto.STRING, number=7)
 
-    state = proto.Field(proto.ENUM, number=8, enum="TransferState",)
+    state = proto.Field(
+        proto.ENUM,
+        number=8,
+        enum="TransferState",
+    )
 
     user_id = proto.Field(proto.INT64, number=11)
 
@@ -299,7 +363,11 @@ class TransferRun(proto.Message):
 
     notification_pubsub_topic = proto.Field(proto.STRING, number=23)
 
-    email_preferences = proto.Field(proto.MESSAGE, number=25, message=EmailPreferences,)
+    email_preferences = proto.Field(
+        proto.MESSAGE,
+        number=25,
+        message=EmailPreferences,
+    )
 
 
 class TransferMessage(proto.Message):
@@ -322,9 +390,17 @@ class TransferMessage(proto.Message):
         WARNING = 2
         ERROR = 3
 
-    message_time = proto.Field(proto.MESSAGE, number=1, message=timestamp.Timestamp,)
+    message_time = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        message=timestamp.Timestamp,
+    )
 
-    severity = proto.Field(proto.ENUM, number=2, enum=MessageSeverity,)
+    severity = proto.Field(
+        proto.ENUM,
+        number=2,
+        enum=MessageSeverity,
+    )
 
     message_text = proto.Field(proto.STRING, number=3)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ import shutil
 import nox
 
 
-BLACK_VERSION = "black==19.10b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
@@ -40,12 +40,14 @@ def lint(session):
     """
     session.install("flake8", BLACK_VERSION)
     session.run(
-        "black", "--check", *BLACK_PATHS,
+        "black",
+        "--check",
+        *BLACK_PATHS,
     )
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python="3.6")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
 
@@ -57,7 +59,8 @@ def blacken(session):
     """
     session.install(BLACK_VERSION)
     session.run(
-        "black", *BLACK_PATHS,
+        "black",
+        *BLACK_PATHS,
     )
 
 
@@ -122,7 +125,9 @@ def system(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install(
-        "mock", "pytest", "google-cloud-testutils",
+        "mock",
+        "pytest",
+        "google-cloud-testutils",
     )
     session.install("-e", ".")
 
@@ -151,7 +156,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx<3.0.0", "alabaster", "recommonmark")
+    session.install("sphinx<3.0.0", "alabaster", "recommonmark", "Jinja2<3.1")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
@@ -173,9 +178,9 @@ def docfx(session):
     """Build the docfx yaml files for this library."""
 
     session.install("-e", ".")
-    # sphinx-docfx-yaml supports up to sphinx version 1.5.5.
-    # https://github.com/docascode/sphinx-docfx-yaml/issues/97
-    session.install("sphinx==1.5.5", "alabaster", "recommonmark", "sphinx-docfx-yaml")
+    session.install(
+        "sphinx<3.0.0", "alabaster", "recommonmark", "sphinx-docfx-yaml", "Jinja2<3.1"
+    )
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "2.1.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = (
-    "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "proto-plus >= 1.4.0",
     "libcst >= 0.2.5",
 )

--- a/tests/unit/gapic/bigquery_datatransfer_v1/test_data_transfer_service.py
+++ b/tests/unit/gapic/bigquery_datatransfer_v1/test_data_transfer_service.py
@@ -404,7 +404,9 @@ def test_data_transfer_service_client_client_options_scopes(
     client_class, transport_class, transport_name
 ):
     # Check the case scopes are provided.
-    options = client_options.ClientOptions(scopes=["1", "2"],)
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
     with mock.patch.object(transport_class, "__init__") as patched:
         patched.return_value = None
         client = client_class(client_options=options)
@@ -476,7 +478,8 @@ def test_get_data_source(
     transport: str = "grpc", request_type=datatransfer.GetDataSourceRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -562,7 +565,8 @@ def test_get_data_source_from_dict():
 @pytest.mark.asyncio
 async def test_get_data_source_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -646,7 +650,9 @@ async def test_get_data_source_async(transport: str = "grpc_asyncio"):
 
 
 def test_get_data_source_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -666,7 +672,10 @@ def test_get_data_source_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -697,11 +706,16 @@ async def test_get_data_source_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_data_source_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client._transport.get_data_source), "__call__") as call:
@@ -710,7 +724,9 @@ def test_get_data_source_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_data_source(name="name_value",)
+        client.get_data_source(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -721,13 +737,16 @@ def test_get_data_source_flattened():
 
 
 def test_get_data_source_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_data_source(
-            datatransfer.GetDataSourceRequest(), name="name_value",
+            datatransfer.GetDataSourceRequest(),
+            name="name_value",
         )
 
 
@@ -749,7 +768,9 @@ async def test_get_data_source_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_data_source(name="name_value",)
+        response = await client.get_data_source(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -769,7 +790,8 @@ async def test_get_data_source_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_data_source(
-            datatransfer.GetDataSourceRequest(), name="name_value",
+            datatransfer.GetDataSourceRequest(),
+            name="name_value",
         )
 
 
@@ -777,7 +799,8 @@ def test_list_data_sources(
     transport: str = "grpc", request_type=datatransfer.ListDataSourcesRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -814,7 +837,8 @@ def test_list_data_sources_from_dict():
 @pytest.mark.asyncio
 async def test_list_data_sources_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -847,7 +871,9 @@ async def test_list_data_sources_async(transport: str = "grpc_asyncio"):
 
 
 def test_list_data_sources_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -869,7 +895,10 @@ def test_list_data_sources_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -900,11 +929,16 @@ async def test_list_data_sources_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_data_sources_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -915,7 +949,9 @@ def test_list_data_sources_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_data_sources(parent="parent_value",)
+        client.list_data_sources(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -926,13 +962,16 @@ def test_list_data_sources_flattened():
 
 
 def test_list_data_sources_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_data_sources(
-            datatransfer.ListDataSourcesRequest(), parent="parent_value",
+            datatransfer.ListDataSourcesRequest(),
+            parent="parent_value",
         )
 
 
@@ -954,7 +993,9 @@ async def test_list_data_sources_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_data_sources(parent="parent_value",)
+        response = await client.list_data_sources(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -974,12 +1015,15 @@ async def test_list_data_sources_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_data_sources(
-            datatransfer.ListDataSourcesRequest(), parent="parent_value",
+            datatransfer.ListDataSourcesRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_data_sources_pager():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -996,13 +1040,20 @@ def test_list_data_sources_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[], next_page_token="def",
+                data_sources=[],
+                next_page_token="def",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(),], next_page_token="ghi",
+                data_sources=[
+                    datatransfer.DataSource(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(), datatransfer.DataSource(),],
+                data_sources=[
+                    datatransfer.DataSource(),
+                    datatransfer.DataSource(),
+                ],
             ),
             RuntimeError,
         )
@@ -1021,7 +1072,9 @@ def test_list_data_sources_pager():
 
 
 def test_list_data_sources_pages():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1038,13 +1091,20 @@ def test_list_data_sources_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[], next_page_token="def",
+                data_sources=[],
+                next_page_token="def",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(),], next_page_token="ghi",
+                data_sources=[
+                    datatransfer.DataSource(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(), datatransfer.DataSource(),],
+                data_sources=[
+                    datatransfer.DataSource(),
+                    datatransfer.DataSource(),
+                ],
             ),
             RuntimeError,
         )
@@ -1076,17 +1136,26 @@ async def test_list_data_sources_async_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[], next_page_token="def",
+                data_sources=[],
+                next_page_token="def",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(),], next_page_token="ghi",
+                data_sources=[
+                    datatransfer.DataSource(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(), datatransfer.DataSource(),],
+                data_sources=[
+                    datatransfer.DataSource(),
+                    datatransfer.DataSource(),
+                ],
             ),
             RuntimeError,
         )
-        async_pager = await client.list_data_sources(request={},)
+        async_pager = await client.list_data_sources(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -1119,13 +1188,20 @@ async def test_list_data_sources_async_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[], next_page_token="def",
+                data_sources=[],
+                next_page_token="def",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(),], next_page_token="ghi",
+                data_sources=[
+                    datatransfer.DataSource(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListDataSourcesResponse(
-                data_sources=[datatransfer.DataSource(), datatransfer.DataSource(),],
+                data_sources=[
+                    datatransfer.DataSource(),
+                    datatransfer.DataSource(),
+                ],
             ),
             RuntimeError,
         )
@@ -1140,7 +1216,8 @@ def test_create_transfer_config(
     transport: str = "grpc", request_type=datatransfer.CreateTransferConfigRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1205,7 +1282,8 @@ def test_create_transfer_config_from_dict():
 @pytest.mark.asyncio
 async def test_create_transfer_config_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1265,7 +1343,9 @@ async def test_create_transfer_config_async(transport: str = "grpc_asyncio"):
 
 
 def test_create_transfer_config_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1287,7 +1367,10 @@ def test_create_transfer_config_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1318,11 +1401,16 @@ async def test_create_transfer_config_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_create_transfer_config_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1349,7 +1437,9 @@ def test_create_transfer_config_flattened():
 
 
 def test_create_transfer_config_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1414,7 +1504,8 @@ def test_update_transfer_config(
     transport: str = "grpc", request_type=datatransfer.UpdateTransferConfigRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1479,7 +1570,8 @@ def test_update_transfer_config_from_dict():
 @pytest.mark.asyncio
 async def test_update_transfer_config_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1539,7 +1631,9 @@ async def test_update_transfer_config_async(transport: str = "grpc_asyncio"):
 
 
 def test_update_transfer_config_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1602,7 +1696,9 @@ async def test_update_transfer_config_field_headers_async():
 
 
 def test_update_transfer_config_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1629,7 +1725,9 @@ def test_update_transfer_config_flattened():
 
 
 def test_update_transfer_config_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -1694,7 +1792,8 @@ def test_delete_transfer_config(
     transport: str = "grpc", request_type=datatransfer.DeleteTransferConfigRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1727,7 +1826,8 @@ def test_delete_transfer_config_from_dict():
 @pytest.mark.asyncio
 async def test_delete_transfer_config_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1754,7 +1854,9 @@ async def test_delete_transfer_config_async(transport: str = "grpc_asyncio"):
 
 
 def test_delete_transfer_config_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -1776,7 +1878,10 @@ def test_delete_transfer_config_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -1805,11 +1910,16 @@ async def test_delete_transfer_config_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_transfer_config_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1820,7 +1930,9 @@ def test_delete_transfer_config_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_transfer_config(name="name_value",)
+        client.delete_transfer_config(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1831,13 +1943,16 @@ def test_delete_transfer_config_flattened():
 
 
 def test_delete_transfer_config_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_transfer_config(
-            datatransfer.DeleteTransferConfigRequest(), name="name_value",
+            datatransfer.DeleteTransferConfigRequest(),
+            name="name_value",
         )
 
 
@@ -1857,7 +1972,9 @@ async def test_delete_transfer_config_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_transfer_config(name="name_value",)
+        response = await client.delete_transfer_config(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1877,7 +1994,8 @@ async def test_delete_transfer_config_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_transfer_config(
-            datatransfer.DeleteTransferConfigRequest(), name="name_value",
+            datatransfer.DeleteTransferConfigRequest(),
+            name="name_value",
         )
 
 
@@ -1885,7 +2003,8 @@ def test_get_transfer_config(
     transport: str = "grpc", request_type=datatransfer.GetTransferConfigRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -1950,7 +2069,8 @@ def test_get_transfer_config_from_dict():
 @pytest.mark.asyncio
 async def test_get_transfer_config_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2010,7 +2130,9 @@ async def test_get_transfer_config_async(transport: str = "grpc_asyncio"):
 
 
 def test_get_transfer_config_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -2032,7 +2154,10 @@ def test_get_transfer_config_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2063,11 +2188,16 @@ async def test_get_transfer_config_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_transfer_config_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2078,7 +2208,9 @@ def test_get_transfer_config_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_transfer_config(name="name_value",)
+        client.get_transfer_config(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2089,13 +2221,16 @@ def test_get_transfer_config_flattened():
 
 
 def test_get_transfer_config_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_transfer_config(
-            datatransfer.GetTransferConfigRequest(), name="name_value",
+            datatransfer.GetTransferConfigRequest(),
+            name="name_value",
         )
 
 
@@ -2117,7 +2252,9 @@ async def test_get_transfer_config_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_transfer_config(name="name_value",)
+        response = await client.get_transfer_config(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2137,7 +2274,8 @@ async def test_get_transfer_config_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_transfer_config(
-            datatransfer.GetTransferConfigRequest(), name="name_value",
+            datatransfer.GetTransferConfigRequest(),
+            name="name_value",
         )
 
 
@@ -2145,7 +2283,8 @@ def test_list_transfer_configs(
     transport: str = "grpc", request_type=datatransfer.ListTransferConfigsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2182,7 +2321,8 @@ def test_list_transfer_configs_from_dict():
 @pytest.mark.asyncio
 async def test_list_transfer_configs_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2215,7 +2355,9 @@ async def test_list_transfer_configs_async(transport: str = "grpc_asyncio"):
 
 
 def test_list_transfer_configs_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -2237,7 +2379,10 @@ def test_list_transfer_configs_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2268,11 +2413,16 @@ async def test_list_transfer_configs_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_transfer_configs_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2283,7 +2433,9 @@ def test_list_transfer_configs_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_transfer_configs(parent="parent_value",)
+        client.list_transfer_configs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2294,13 +2446,16 @@ def test_list_transfer_configs_flattened():
 
 
 def test_list_transfer_configs_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_transfer_configs(
-            datatransfer.ListTransferConfigsRequest(), parent="parent_value",
+            datatransfer.ListTransferConfigsRequest(),
+            parent="parent_value",
         )
 
 
@@ -2322,7 +2477,9 @@ async def test_list_transfer_configs_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_transfer_configs(parent="parent_value",)
+        response = await client.list_transfer_configs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2342,12 +2499,15 @@ async def test_list_transfer_configs_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_transfer_configs(
-            datatransfer.ListTransferConfigsRequest(), parent="parent_value",
+            datatransfer.ListTransferConfigsRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_transfer_configs_pager():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2364,10 +2524,14 @@ def test_list_transfer_configs_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[], next_page_token="def",
+                transfer_configs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[transfer.TransferConfig(),], next_page_token="ghi",
+                transfer_configs=[
+                    transfer.TransferConfig(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferConfigsResponse(
                 transfer_configs=[
@@ -2392,7 +2556,9 @@ def test_list_transfer_configs_pager():
 
 
 def test_list_transfer_configs_pages():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2409,10 +2575,14 @@ def test_list_transfer_configs_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[], next_page_token="def",
+                transfer_configs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[transfer.TransferConfig(),], next_page_token="ghi",
+                transfer_configs=[
+                    transfer.TransferConfig(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferConfigsResponse(
                 transfer_configs=[
@@ -2450,10 +2620,14 @@ async def test_list_transfer_configs_async_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[], next_page_token="def",
+                transfer_configs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[transfer.TransferConfig(),], next_page_token="ghi",
+                transfer_configs=[
+                    transfer.TransferConfig(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferConfigsResponse(
                 transfer_configs=[
@@ -2463,7 +2637,9 @@ async def test_list_transfer_configs_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_transfer_configs(request={},)
+        async_pager = await client.list_transfer_configs(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -2496,10 +2672,14 @@ async def test_list_transfer_configs_async_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[], next_page_token="def",
+                transfer_configs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferConfigsResponse(
-                transfer_configs=[transfer.TransferConfig(),], next_page_token="ghi",
+                transfer_configs=[
+                    transfer.TransferConfig(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferConfigsResponse(
                 transfer_configs=[
@@ -2520,7 +2700,8 @@ def test_schedule_transfer_runs(
     transport: str = "grpc", request_type=datatransfer.ScheduleTransferRunsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2553,7 +2734,8 @@ def test_schedule_transfer_runs_from_dict():
 @pytest.mark.asyncio
 async def test_schedule_transfer_runs_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2582,7 +2764,9 @@ async def test_schedule_transfer_runs_async(transport: str = "grpc_asyncio"):
 
 
 def test_schedule_transfer_runs_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -2604,7 +2788,10 @@ def test_schedule_transfer_runs_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2635,11 +2822,16 @@ async def test_schedule_transfer_runs_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_schedule_transfer_runs_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2673,7 +2865,9 @@ def test_schedule_transfer_runs_flattened():
 
 
 def test_schedule_transfer_runs_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
@@ -2747,7 +2941,8 @@ def test_start_manual_transfer_runs(
     transport: str = "grpc", request_type=datatransfer.StartManualTransferRunsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2780,7 +2975,8 @@ def test_start_manual_transfer_runs_from_dict():
 @pytest.mark.asyncio
 async def test_start_manual_transfer_runs_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2809,7 +3005,9 @@ async def test_start_manual_transfer_runs_async(transport: str = "grpc_asyncio")
 
 
 def test_start_manual_transfer_runs_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -2831,7 +3029,10 @@ def test_start_manual_transfer_runs_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -2862,14 +3063,18 @@ async def test_start_manual_transfer_runs_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_get_transfer_run(
     transport: str = "grpc", request_type=datatransfer.GetTransferRunRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2922,7 +3127,8 @@ def test_get_transfer_run_from_dict():
 @pytest.mark.asyncio
 async def test_get_transfer_run_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -2970,7 +3176,9 @@ async def test_get_transfer_run_async(transport: str = "grpc_asyncio"):
 
 
 def test_get_transfer_run_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -2992,7 +3200,10 @@ def test_get_transfer_run_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -3023,11 +3234,16 @@ async def test_get_transfer_run_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_get_transfer_run_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3038,7 +3254,9 @@ def test_get_transfer_run_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.get_transfer_run(name="name_value",)
+        client.get_transfer_run(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3049,13 +3267,16 @@ def test_get_transfer_run_flattened():
 
 
 def test_get_transfer_run_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.get_transfer_run(
-            datatransfer.GetTransferRunRequest(), name="name_value",
+            datatransfer.GetTransferRunRequest(),
+            name="name_value",
         )
 
 
@@ -3077,7 +3298,9 @@ async def test_get_transfer_run_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.get_transfer_run(name="name_value",)
+        response = await client.get_transfer_run(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3097,7 +3320,8 @@ async def test_get_transfer_run_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.get_transfer_run(
-            datatransfer.GetTransferRunRequest(), name="name_value",
+            datatransfer.GetTransferRunRequest(),
+            name="name_value",
         )
 
 
@@ -3105,7 +3329,8 @@ def test_delete_transfer_run(
     transport: str = "grpc", request_type=datatransfer.DeleteTransferRunRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3138,7 +3363,8 @@ def test_delete_transfer_run_from_dict():
 @pytest.mark.asyncio
 async def test_delete_transfer_run_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3165,7 +3391,9 @@ async def test_delete_transfer_run_async(transport: str = "grpc_asyncio"):
 
 
 def test_delete_transfer_run_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -3187,7 +3415,10 @@ def test_delete_transfer_run_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -3216,11 +3447,16 @@ async def test_delete_transfer_run_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_delete_transfer_run_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3231,7 +3467,9 @@ def test_delete_transfer_run_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.delete_transfer_run(name="name_value",)
+        client.delete_transfer_run(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3242,13 +3480,16 @@ def test_delete_transfer_run_flattened():
 
 
 def test_delete_transfer_run_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.delete_transfer_run(
-            datatransfer.DeleteTransferRunRequest(), name="name_value",
+            datatransfer.DeleteTransferRunRequest(),
+            name="name_value",
         )
 
 
@@ -3268,7 +3509,9 @@ async def test_delete_transfer_run_flattened_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.delete_transfer_run(name="name_value",)
+        response = await client.delete_transfer_run(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3288,7 +3531,8 @@ async def test_delete_transfer_run_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.delete_transfer_run(
-            datatransfer.DeleteTransferRunRequest(), name="name_value",
+            datatransfer.DeleteTransferRunRequest(),
+            name="name_value",
         )
 
 
@@ -3296,7 +3540,8 @@ def test_list_transfer_runs(
     transport: str = "grpc", request_type=datatransfer.ListTransferRunsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3333,7 +3578,8 @@ def test_list_transfer_runs_from_dict():
 @pytest.mark.asyncio
 async def test_list_transfer_runs_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3366,7 +3612,9 @@ async def test_list_transfer_runs_async(transport: str = "grpc_asyncio"):
 
 
 def test_list_transfer_runs_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -3388,7 +3636,10 @@ def test_list_transfer_runs_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -3419,11 +3670,16 @@ async def test_list_transfer_runs_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_transfer_runs_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3434,7 +3690,9 @@ def test_list_transfer_runs_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_transfer_runs(parent="parent_value",)
+        client.list_transfer_runs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3445,13 +3703,16 @@ def test_list_transfer_runs_flattened():
 
 
 def test_list_transfer_runs_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_transfer_runs(
-            datatransfer.ListTransferRunsRequest(), parent="parent_value",
+            datatransfer.ListTransferRunsRequest(),
+            parent="parent_value",
         )
 
 
@@ -3473,7 +3734,9 @@ async def test_list_transfer_runs_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_transfer_runs(parent="parent_value",)
+        response = await client.list_transfer_runs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3493,12 +3756,15 @@ async def test_list_transfer_runs_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_transfer_runs(
-            datatransfer.ListTransferRunsRequest(), parent="parent_value",
+            datatransfer.ListTransferRunsRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_transfer_runs_pager():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3515,13 +3781,20 @@ def test_list_transfer_runs_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[], next_page_token="def",
+                transfer_runs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(),], next_page_token="ghi",
+                transfer_runs=[
+                    transfer.TransferRun(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(), transfer.TransferRun(),],
+                transfer_runs=[
+                    transfer.TransferRun(),
+                    transfer.TransferRun(),
+                ],
             ),
             RuntimeError,
         )
@@ -3540,7 +3813,9 @@ def test_list_transfer_runs_pager():
 
 
 def test_list_transfer_runs_pages():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3557,13 +3832,20 @@ def test_list_transfer_runs_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[], next_page_token="def",
+                transfer_runs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(),], next_page_token="ghi",
+                transfer_runs=[
+                    transfer.TransferRun(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(), transfer.TransferRun(),],
+                transfer_runs=[
+                    transfer.TransferRun(),
+                    transfer.TransferRun(),
+                ],
             ),
             RuntimeError,
         )
@@ -3595,17 +3877,26 @@ async def test_list_transfer_runs_async_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[], next_page_token="def",
+                transfer_runs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(),], next_page_token="ghi",
+                transfer_runs=[
+                    transfer.TransferRun(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(), transfer.TransferRun(),],
+                transfer_runs=[
+                    transfer.TransferRun(),
+                    transfer.TransferRun(),
+                ],
             ),
             RuntimeError,
         )
-        async_pager = await client.list_transfer_runs(request={},)
+        async_pager = await client.list_transfer_runs(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -3638,13 +3929,20 @@ async def test_list_transfer_runs_async_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[], next_page_token="def",
+                transfer_runs=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(),], next_page_token="ghi",
+                transfer_runs=[
+                    transfer.TransferRun(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferRunsResponse(
-                transfer_runs=[transfer.TransferRun(), transfer.TransferRun(),],
+                transfer_runs=[
+                    transfer.TransferRun(),
+                    transfer.TransferRun(),
+                ],
             ),
             RuntimeError,
         )
@@ -3659,7 +3957,8 @@ def test_list_transfer_logs(
     transport: str = "grpc", request_type=datatransfer.ListTransferLogsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3696,7 +3995,8 @@ def test_list_transfer_logs_from_dict():
 @pytest.mark.asyncio
 async def test_list_transfer_logs_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -3729,7 +4029,9 @@ async def test_list_transfer_logs_async(transport: str = "grpc_asyncio"):
 
 
 def test_list_transfer_logs_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -3751,7 +4053,10 @@ def test_list_transfer_logs_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -3782,11 +4087,16 @@ async def test_list_transfer_logs_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "parent=parent/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "parent=parent/value",
+    ) in kw["metadata"]
 
 
 def test_list_transfer_logs_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3797,7 +4107,9 @@ def test_list_transfer_logs_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.list_transfer_logs(parent="parent_value",)
+        client.list_transfer_logs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3808,13 +4120,16 @@ def test_list_transfer_logs_flattened():
 
 
 def test_list_transfer_logs_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.list_transfer_logs(
-            datatransfer.ListTransferLogsRequest(), parent="parent_value",
+            datatransfer.ListTransferLogsRequest(),
+            parent="parent_value",
         )
 
 
@@ -3836,7 +4151,9 @@ async def test_list_transfer_logs_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.list_transfer_logs(parent="parent_value",)
+        response = await client.list_transfer_logs(
+            parent="parent_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3856,12 +4173,15 @@ async def test_list_transfer_logs_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.list_transfer_logs(
-            datatransfer.ListTransferLogsRequest(), parent="parent_value",
+            datatransfer.ListTransferLogsRequest(),
+            parent="parent_value",
         )
 
 
 def test_list_transfer_logs_pager():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3878,10 +4198,14 @@ def test_list_transfer_logs_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[], next_page_token="def",
+                transfer_messages=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[transfer.TransferMessage(),], next_page_token="ghi",
+                transfer_messages=[
+                    transfer.TransferMessage(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferLogsResponse(
                 transfer_messages=[
@@ -3906,7 +4230,9 @@ def test_list_transfer_logs_pager():
 
 
 def test_list_transfer_logs_pages():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials,
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3923,10 +4249,14 @@ def test_list_transfer_logs_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[], next_page_token="def",
+                transfer_messages=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[transfer.TransferMessage(),], next_page_token="ghi",
+                transfer_messages=[
+                    transfer.TransferMessage(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferLogsResponse(
                 transfer_messages=[
@@ -3964,10 +4294,14 @@ async def test_list_transfer_logs_async_pager():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[], next_page_token="def",
+                transfer_messages=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[transfer.TransferMessage(),], next_page_token="ghi",
+                transfer_messages=[
+                    transfer.TransferMessage(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferLogsResponse(
                 transfer_messages=[
@@ -3977,7 +4311,9 @@ async def test_list_transfer_logs_async_pager():
             ),
             RuntimeError,
         )
-        async_pager = await client.list_transfer_logs(request={},)
+        async_pager = await client.list_transfer_logs(
+            request={},
+        )
         assert async_pager.next_page_token == "abc"
         responses = []
         async for response in async_pager:
@@ -4010,10 +4346,14 @@ async def test_list_transfer_logs_async_pages():
                 next_page_token="abc",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[], next_page_token="def",
+                transfer_messages=[],
+                next_page_token="def",
             ),
             datatransfer.ListTransferLogsResponse(
-                transfer_messages=[transfer.TransferMessage(),], next_page_token="ghi",
+                transfer_messages=[
+                    transfer.TransferMessage(),
+                ],
+                next_page_token="ghi",
             ),
             datatransfer.ListTransferLogsResponse(
                 transfer_messages=[
@@ -4034,7 +4374,8 @@ def test_check_valid_creds(
     transport: str = "grpc", request_type=datatransfer.CheckValidCredsRequest
 ):
     client = DataTransferServiceClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4046,7 +4387,9 @@ def test_check_valid_creds(
         type(client._transport.check_valid_creds), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
-        call.return_value = datatransfer.CheckValidCredsResponse(has_valid_creds=True,)
+        call.return_value = datatransfer.CheckValidCredsResponse(
+            has_valid_creds=True,
+        )
 
         response = client.check_valid_creds(request)
 
@@ -4069,7 +4412,8 @@ def test_check_valid_creds_from_dict():
 @pytest.mark.asyncio
 async def test_check_valid_creds_async(transport: str = "grpc_asyncio"):
     client = DataTransferServiceAsyncClient(
-        credentials=credentials.AnonymousCredentials(), transport=transport,
+        credentials=credentials.AnonymousCredentials(),
+        transport=transport,
     )
 
     # Everything is optional in proto3 as far as the runtime is concerned,
@@ -4082,7 +4426,9 @@ async def test_check_valid_creds_async(transport: str = "grpc_asyncio"):
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            datatransfer.CheckValidCredsResponse(has_valid_creds=True,)
+            datatransfer.CheckValidCredsResponse(
+                has_valid_creds=True,
+            )
         )
 
         response = await client.check_valid_creds(request)
@@ -4100,7 +4446,9 @@ async def test_check_valid_creds_async(transport: str = "grpc_asyncio"):
 
 
 def test_check_valid_creds_field_headers():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Any value that is part of the HTTP/1.1 URI should be sent as
     # a field header. Set these to a non-empty value.
@@ -4122,7 +4470,10 @@ def test_check_valid_creds_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 @pytest.mark.asyncio
@@ -4153,11 +4504,16 @@ async def test_check_valid_creds_field_headers_async():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
-    assert ("x-goog-request-params", "name=name/value",) in kw["metadata"]
+    assert (
+        "x-goog-request-params",
+        "name=name/value",
+    ) in kw["metadata"]
 
 
 def test_check_valid_creds_flattened():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4168,7 +4524,9 @@ def test_check_valid_creds_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        client.check_valid_creds(name="name_value",)
+        client.check_valid_creds(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4179,13 +4537,16 @@ def test_check_valid_creds_flattened():
 
 
 def test_check_valid_creds_flattened_error():
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
 
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
         client.check_valid_creds(
-            datatransfer.CheckValidCredsRequest(), name="name_value",
+            datatransfer.CheckValidCredsRequest(),
+            name="name_value",
         )
 
 
@@ -4207,7 +4568,9 @@ async def test_check_valid_creds_flattened_async():
         )
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        response = await client.check_valid_creds(name="name_value",)
+        response = await client.check_valid_creds(
+            name="name_value",
+        )
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4227,7 +4590,8 @@ async def test_check_valid_creds_flattened_error_async():
     # fields is an error.
     with pytest.raises(ValueError):
         await client.check_valid_creds(
-            datatransfer.CheckValidCredsRequest(), name="name_value",
+            datatransfer.CheckValidCredsRequest(),
+            name="name_value",
         )
 
 
@@ -4238,7 +4602,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = DataTransferServiceClient(
-            credentials=credentials.AnonymousCredentials(), transport=transport,
+            credentials=credentials.AnonymousCredentials(),
+            transport=transport,
         )
 
     # It is an error to provide a credentials file and a transport instance.
@@ -4257,7 +4622,8 @@ def test_credentials_transport_error():
     )
     with pytest.raises(ValueError):
         client = DataTransferServiceClient(
-            client_options={"scopes": ["1", "2"]}, transport=transport,
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
         )
 
 
@@ -4302,8 +4668,13 @@ def test_transport_adc(transport_class):
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = DataTransferServiceClient(credentials=credentials.AnonymousCredentials(),)
-    assert isinstance(client._transport, transports.DataTransferServiceGrpcTransport,)
+    client = DataTransferServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client._transport,
+        transports.DataTransferServiceGrpcTransport,
+    )
 
 
 def test_data_transfer_service_base_transport_error():
@@ -4358,7 +4729,8 @@ def test_data_transfer_service_base_transport_with_credentials_file():
         Transport.return_value = None
         load_creds.return_value = (credentials.AnonymousCredentials(), None)
         transport = transports.DataTransferServiceTransport(
-            credentials_file="credentials.json", quota_project_id="octopus",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
         )
         load_creds.assert_called_once_with(
             "credentials.json",
@@ -4428,7 +4800,8 @@ def test_data_transfer_service_grpc_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.DataTransferServiceGrpcTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -4439,7 +4812,8 @@ def test_data_transfer_service_grpc_asyncio_transport_channel():
 
     # Check that channel is used if provided.
     transport = transports.DataTransferServiceGrpcAsyncIOTransport(
-        host="squid.clam.whelk", channel=channel,
+        host="squid.clam.whelk",
+        channel=channel,
     )
     assert transport.grpc_channel == channel
     assert transport._host == "squid.clam.whelk:443"
@@ -4537,7 +4911,8 @@ def test_transfer_config_path():
     transfer_config = "clam"
 
     expected = "projects/{project}/transferConfigs/{transfer_config}".format(
-        project=project, transfer_config=transfer_config,
+        project=project,
+        transfer_config=transfer_config,
     )
     actual = DataTransferServiceClient.transfer_config_path(project, transfer_config)
     assert expected == actual
@@ -4562,7 +4937,8 @@ def test_client_withDEFAULT_CLIENT_INFO():
         transports.DataTransferServiceTransport, "_prep_wrapped_messages"
     ) as prep:
         client = DataTransferServiceClient(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)
 
@@ -4571,6 +4947,7 @@ def test_client_withDEFAULT_CLIENT_INFO():
     ) as prep:
         transport_class = DataTransferServiceClient.get_transport_class()
         transport = transport_class(
-            credentials=credentials.AnonymousCredentials(), client_info=client_info,
+            credentials=credentials.AnonymousCredentials(),
+            client_info=client_info,
         )
         prep.assert_called_once_with(client_info)


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v2**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566