### PR TITLE
fix: replaces deprecated snippet

### DIFF
--- a/samples/snippets/manage_transfer_configs.py
+++ b/samples/snippets/manage_transfer_configs.py
@@ -162,7 +162,7 @@ def schedule_backfill_manual_transfer(override_values={}):
 
 
     # Replace with your transfer configuration name
-    transfer_config_name = "projects/<1234>/locations/<us>/transferConfigs/<abcd>"
+    transfer_config_name = "projects/1234/locations/us/transferConfigs/abcd"
     # [END bigquerydatatransfer_start_manual_transfer]
     # To facilitate testing, we replace values with alternatives
     # provided by the testing harness.
@@ -190,10 +190,7 @@ def schedule_backfill_manual_transfer(override_values={}):
 
     # Initialize request argument(s)
     request = StartManualTransferRunsRequest(
-        #parent="projects/240264904610/locations/us/transferConfigs/641f4360-0000-26d6-b940-f403045ed80c",
-        # parent="<your_transfer_config>"
         parent=transfer_config_name,
-        # parent="projects/xxxx/locations/us/transferConfigs/yyyy"
         requested_time_range=requested_time_range,
     )
 

--- a/samples/snippets/manage_transfer_configs.py
+++ b/samples/snippets/manage_transfer_configs.py
@@ -147,6 +147,67 @@ def schedule_backfill(override_values={}):
     return response.runs
 
 
+def schedule_backfill_manual_transfer(override_values={}):
+    # [START bigquerydatatransfer_start_manual_transfer]
+    import datetime
+
+    from google.cloud import bigquery_datatransfer_v1
+    from google.cloud.bigquery_datatransfer_v1 import (
+        DataTransferServiceClient,
+        StartManualTransferRunsRequest,
+    )
+
+    # Create a client object
+    client = DataTransferServiceClient()
+
+
+    # Replace with your transfer configuration name
+    transfer_config_name = "projects/<1234>/locations/<us>/transferConfigs/<abcd>"
+    # [END bigquerydatatransfer_start_manual_transfer]
+    # To facilitate testing, we replace values with alternatives
+    # provided by the testing harness.
+    transfer_config_name = override_values.get(
+        "transfer_config_name", transfer_config_name
+    )
+    # [START bigquerydatatransfer_start_manual_transfer]
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start_time = now - datetime.timedelta(days=5)
+    end_time = now - datetime.timedelta(days=2)
+
+    # Some data sources, such as scheduled_query only support daily run.
+    # Truncate start_time and end_time to midnight time (00:00AM UTC).
+    start_time = datetime.datetime(
+        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
+    )
+    end_time = datetime.datetime(
+        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
+    )
+
+    requested_time_range = StartManualTransferRunsRequest.TimeRange(
+        start_time=start_time,
+        end_time=end_time,
+    )
+
+    # Initialize request argument(s)
+    request = StartManualTransferRunsRequest(
+        #parent="projects/240264904610/locations/us/transferConfigs/641f4360-0000-26d6-b940-f403045ed80c",
+        # parent="<your_transfer_config>"
+        parent=transfer_config_name,
+        # parent="projects/xxxx/locations/us/transferConfigs/yyyy"
+        requested_time_range=requested_time_range,
+    )
+
+    # Make the request
+    response = client.start_manual_transfer_runs(request=request)
+
+    # Handle the response
+    print("Started manual transfer runs:")
+    for run in response.runs:
+        print(f"backfill: {run.run_time} run: {run.name}")
+    # [END bigquerydatatransfer_start_manual_transfer]
+    return response.runs
+
+
 def delete_config(override_values={}):
     # [START bigquerydatatransfer_delete_transfer]
     import google.api_core.exceptions

--- a/samples/snippets/manage_transfer_configs.py
+++ b/samples/snippets/manage_transfer_configs.py
@@ -160,7 +160,6 @@ def schedule_backfill_manual_transfer(override_values={}):
     # Create a client object
     client = DataTransferServiceClient()
 
-
     # Replace with your transfer configuration name
     transfer_config_name = "projects/1234/locations/us/transferConfigs/abcd"
     # [END bigquerydatatransfer_start_manual_transfer]

--- a/samples/snippets/manage_transfer_configs.py
+++ b/samples/snippets/manage_transfer_configs.py
@@ -151,7 +151,6 @@ def schedule_backfill_manual_transfer(override_values={}):
     # [START bigquerydatatransfer_start_manual_transfer]
     import datetime
 
-    from google.cloud import bigquery_datatransfer_v1
     from google.cloud.bigquery_datatransfer_v1 import (
         DataTransferServiceClient,
         StartManualTransferRunsRequest,

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -59,6 +59,7 @@ def test_schedule_backfill(capsys, transfer_config_name):
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
+    print("TEST SCHEDULE BACKFILL", *runs, sep="\n")
     assert len(runs) == 4
 
 
@@ -71,7 +72,7 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
-    print(*runs, sep="\n")
+    print("TEST SB MANUAL TRANSFER", *runs, sep="\n")
     assert len(runs) == 4
 
 

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -67,7 +67,7 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
         {"transfer_config_name": transfer_config_name}
     )
     out, _ = capsys.readouterr()
-    assert "Started transfer runs:" in out
+    assert "Started manual transfer runs:" in out
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -71,6 +71,7 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
+    print(*runs, sep="\n")
     assert len(runs) == 4
 
 

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -60,7 +60,7 @@ def test_schedule_backfill(capsys, transfer_config_name):
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
     print("TEST SCHEDULE BACKFILL", *runs, sep="\n")
-    assert len(runs) == 4
+    assert len(runs) == 5 # hoping to cause this to fail
 
 
 def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -60,6 +60,26 @@ def test_schedule_backfill(capsys, transfer_config_name):
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
     print("TEST SCHEDULE BACKFILL", *runs, sep="\n")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start_time = now - datetime.timedelta(days=5)
+    end_time = now - datetime.timedelta(days=2)
+
+    # Some data sources, such as scheduled_query only support daily run.
+    # Truncate start_time and end_time to midnight time (00:00AM UTC).
+    start_time = datetime.datetime(
+        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
+    )
+    end_time = datetime.datetime(
+        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
+    )
+
+    requested_time_range = StartManualTransferRunsRequest.TimeRange(
+        start_time=start_time,
+        end_time=end_time,
+    )
+    print("TEST STIME, ETIME", start_time, end_time)
+    print("REQUESTED TIME RANGE", requested_time_range) 
+    
     assert len(runs) == 5 # hoping to cause this to fail
 
 
@@ -73,6 +93,27 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
     print("TEST SB MANUAL TRANSFER", *runs, sep="\n")
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    start_time = now - datetime.timedelta(days=5)
+    end_time = now - datetime.timedelta(days=2)
+
+    # Some data sources, such as scheduled_query only support daily run.
+    # Truncate start_time and end_time to midnight time (00:00AM UTC).
+    start_time = datetime.datetime(
+        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
+    )
+    end_time = datetime.datetime(
+        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
+    )
+
+    requested_time_range = StartManualTransferRunsRequest.TimeRange(
+        start_time=start_time,
+        end_time=end_time,
+    )
+    print("TEST STIME, ETIME", start_time, end_time)
+    print("REQUESTED TIME RANGE", requested_time_range) 
+
     assert len(runs) == 4
 
 

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -60,6 +60,7 @@ def test_schedule_backfill(capsys, transfer_config_name):
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
     print("TEST SCHEDULE BACKFILL", *runs, sep="\n")
+    import datetime
     now = datetime.datetime.now(datetime.timezone.utc)
     start_time = now - datetime.timedelta(days=5)
     end_time = now - datetime.timedelta(days=2)
@@ -72,7 +73,7 @@ def test_schedule_backfill(capsys, transfer_config_name):
     end_time = datetime.datetime(
         end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
     )
-
+    from google.cloud.bigquery_datatransfer_v1 import StartManualTransferRunsRequest
     requested_time_range = StartManualTransferRunsRequest.TimeRange(
         start_time=start_time,
         end_time=end_time,
@@ -93,7 +94,7 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
     print("TEST SB MANUAL TRANSFER", *runs, sep="\n")
-
+    import datetime
     now = datetime.datetime.now(datetime.timezone.utc)
     start_time = now - datetime.timedelta(days=5)
     end_time = now - datetime.timedelta(days=2)
@@ -106,7 +107,7 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     end_time = datetime.datetime(
         end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
     )
-
+    from google.cloud.bigquery_datatransfer_v1 import StartManualTransferRunsRequest
     requested_time_range = StartManualTransferRunsRequest.TimeRange(
         start_time=start_time,
         end_time=end_time,

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -62,6 +62,18 @@ def test_schedule_backfill(capsys, transfer_config_name):
     assert len(runs) == 4
 
 
+def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
+    runs = manage_transfer_configs.schedule_backfill_manual_transfer(
+        {"transfer_config_name": transfer_config_name}
+    )
+    out, _ = capsys.readouterr()
+    assert "Started transfer runs:" in out
+    # Run IDs should include the transfer name in their path.
+    assert transfer_config_name in out
+    # Check that there are runs for 5, 4, 3, and 2 days ago.
+    assert len(runs) == 4
+
+
 def test_delete_config(capsys, transfer_config_name):
     # transfer_config_name fixture in conftest.py calls the delete config
     # sample. To conserve limited BQ-DTS quota we only make basic checks.

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -59,29 +59,7 @@ def test_schedule_backfill(capsys, transfer_config_name):
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
     # Check that there are runs for 5, 4, 3, and 2 days ago.
-    print("TEST SCHEDULE BACKFILL", *runs, sep="\n")
-    import datetime
-    now = datetime.datetime.now(datetime.timezone.utc)
-    start_time = now - datetime.timedelta(days=5)
-    end_time = now - datetime.timedelta(days=2)
-
-    # Some data sources, such as scheduled_query only support daily run.
-    # Truncate start_time and end_time to midnight time (00:00AM UTC).
-    start_time = datetime.datetime(
-        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
-    )
-    end_time = datetime.datetime(
-        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
-    )
-    from google.cloud.bigquery_datatransfer_v1 import StartManualTransferRunsRequest
-    requested_time_range = StartManualTransferRunsRequest.TimeRange(
-        start_time=start_time,
-        end_time=end_time,
-    )
-    print("TEST STIME, ETIME", start_time, end_time)
-    print("REQUESTED TIME RANGE", requested_time_range) 
-    
-    assert len(runs) == 5 # hoping to cause this to fail
+    assert len(runs) == 4
 
 
 def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
@@ -92,30 +70,8 @@ def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     assert "Started manual transfer runs:" in out
     # Run IDs should include the transfer name in their path.
     assert transfer_config_name in out
-    # Check that there are runs for 5, 4, 3, and 2 days ago.
-    print("TEST SB MANUAL TRANSFER", *runs, sep="\n")
-    import datetime
-    now = datetime.datetime.now(datetime.timezone.utc)
-    start_time = now - datetime.timedelta(days=5)
-    end_time = now - datetime.timedelta(days=2)
-
-    # Some data sources, such as scheduled_query only support daily run.
-    # Truncate start_time and end_time to midnight time (00:00AM UTC).
-    start_time = datetime.datetime(
-        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
-    )
-    end_time = datetime.datetime(
-        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
-    )
-    from google.cloud.bigquery_datatransfer_v1 import StartManualTransferRunsRequest
-    requested_time_range = StartManualTransferRunsRequest.TimeRange(
-        start_time=start_time,
-        end_time=end_time,
-    )
-    print("TEST STIME, ETIME", start_time, end_time)
-    print("REQUESTED TIME RANGE", requested_time_range) 
-
-    assert len(runs) == 4
+    # Check that there are three runs for between 2 and 5 days ago.
+    assert len(runs) == 3
 
 
 def test_delete_config(capsys, transfer_config_name):


### PR DESCRIPTION
Replaces a deprecated snippet with an alternate snippet.

* removing the code that demos `schedule_transfer_run()`
* replacing with code that demos `start_manual_transfer_runs()`

May need to do this in several steps so that there are no gaps in the documentation status.

Fixes internal bug: #191232835
