### PR TITLE
bug: Remove deprecated sample

### DIFF
--- a/samples/snippets/manage_transfer_configs.py
+++ b/samples/snippets/manage_transfer_configs.py
@@ -105,48 +105,6 @@ def update_credentials_with_service_account(override_values={}):
     return transfer_config
 
 
-def schedule_backfill(override_values={}):
-    # [START bigquerydatatransfer_schedule_backfill]
-    import datetime
-
-    from google.cloud import bigquery_datatransfer
-
-    transfer_client = bigquery_datatransfer.DataTransferServiceClient()
-
-    transfer_config_name = "projects/1234/locations/us/transferConfigs/abcd"
-    # [END bigquerydatatransfer_schedule_backfill]
-    # To facilitate testing, we replace values with alternatives
-    # provided by the testing harness.
-    transfer_config_name = override_values.get(
-        "transfer_config_name", transfer_config_name
-    )
-    # [START bigquerydatatransfer_schedule_backfill]
-    now = datetime.datetime.now(datetime.timezone.utc)
-    start_time = now - datetime.timedelta(days=5)
-    end_time = now - datetime.timedelta(days=2)
-
-    # Some data sources, such as scheduled_query only support daily run.
-    # Truncate start_time and end_time to midnight time (00:00AM UTC).
-    start_time = datetime.datetime(
-        start_time.year, start_time.month, start_time.day, tzinfo=datetime.timezone.utc
-    )
-    end_time = datetime.datetime(
-        end_time.year, end_time.month, end_time.day, tzinfo=datetime.timezone.utc
-    )
-
-    response = transfer_client.schedule_transfer_runs(
-        parent=transfer_config_name,
-        start_time=start_time,
-        end_time=end_time,
-    )
-
-    print("Started transfer runs:")
-    for run in response.runs:
-        print(f"backfill: {run.run_time} run: {run.name}")
-    # [END bigquerydatatransfer_schedule_backfill]
-    return response.runs
-
-
 def schedule_backfill_manual_transfer(override_values={}):
     # [START bigquerydatatransfer_start_manual_transfer]
     import datetime

--- a/samples/snippets/manage_transfer_configs_test.py
+++ b/samples/snippets/manage_transfer_configs_test.py
@@ -50,18 +50,6 @@ def test_update_credentials_with_service_account(
     assert transfer_config_name in out
 
 
-def test_schedule_backfill(capsys, transfer_config_name):
-    runs = manage_transfer_configs.schedule_backfill(
-        {"transfer_config_name": transfer_config_name}
-    )
-    out, _ = capsys.readouterr()
-    assert "Started transfer runs:" in out
-    # Run IDs should include the transfer name in their path.
-    assert transfer_config_name in out
-    # Check that there are runs for 5, 4, 3, and 2 days ago.
-    assert len(runs) == 4
-
-
 def test_schedule_backfill_manual_transfer(capsys, transfer_config_name):
     runs = manage_transfer_configs.schedule_backfill_manual_transfer(
         {"transfer_config_name": transfer_config_name}


### PR DESCRIPTION
Part 2 of a series of PRs to remove and replace a deprecated sample:

* removes the code that demos `schedule_transfer_run()`

That code was replaced with code that demos `start_manual_transfer_runs()` in the following PR: https://github.com/googleapis/python-bigquery-datatransfer/pull/448

Fixes internal bug: #191232835